### PR TITLE
Typo fix.

### DIFF
--- a/Alcatraz/Alcatraz.m
+++ b/Alcatraz/Alcatraz.m
@@ -55,7 +55,7 @@ static Alcatraz *sharedPlugin;
         [[NSOperationQueue mainQueue] addOperationWithBlock:^{
 
 		   [[NSNotificationCenter defaultCenter] addObserver:self
-										    selector:@selector(applicationDidFinishLaunching:)
+										    selector:@selector(xcodeDidFinishLaunching:)
 										    name:NSApplicationDidFinishLaunchingNotification
 										  object:nil];
         }];


### PR DESCRIPTION
Forgot to change `applicationDidFinishLaunching:` to `xcodeDidFinishLaunching`.

Signed-off-by: Clement Padovani <ClementPadovani@users.noreply.github.com>